### PR TITLE
Limit available characters for placeholder names to fix misrecognition of operators starting with a colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ q := `SELECT name, age, recorded_at FROM user
       WHERE name LIKE :like AND age IN :age[2]`
 ```
 
+A placeholder name must start with a colon followed by either of or a combination of alphabets, numbers, or underscores.
+
 `:like` and `:age[2]` are the named placeholders.
 They are internally converted to unnamed ones as below:
 

--- a/placeholder/replace.go
+++ b/placeholder/replace.go
@@ -51,7 +51,8 @@ func (r *rep) unnamedToStd() {
 func (r *rep) namedToStd() map[string]interface{} {
 	bindModel := make(map[string]interface{})
 
-	exp := regexp.MustCompile(`(?im)(\s+in)\s+:([^\s\[\),]+)\[(\d*)\]([\s\)/,]|` + regexp.QuoteMeta(tempReplacement) + `|$)`)
+	// Replacement of in :xxxx[xx]
+	exp := regexp.MustCompile(`(?im)(\s+in)\s+:([a-z0-9_]+)\[(\d*)\]([\s\)/,]|` + regexp.QuoteMeta(tempReplacement) + `|$)`)
 	matches := exp.FindAllStringSubmatch(r.query, -1)
 
 	for _, v := range matches {
@@ -60,7 +61,8 @@ func (r *rep) namedToStd() map[string]interface{} {
 		bindModel[v[2]] = make([]interface{}, num)
 	}
 
-	exp = regexp.MustCompile(`(?m):([^\s\[\)/,]+)([\s\)/,]|$)`)
+	// Replacement of :xxxx
+	exp = regexp.MustCompile(`(?m):([a-zA-Z0-9_]+)([\s\)/,]|$)`)
 	matches = exp.FindAllStringSubmatch(r.query, -1)
 
 	for _, v := range matches {


### PR DESCRIPTION
#4 